### PR TITLE
Lift Malloc

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -119,11 +119,14 @@ endif
 # APPL implemenation
 ifeq ($(APPL_IMPL), APPL_IMPL_APPLRTS)
 	RISCV_GCC_OPTS +=-DAPPL_IMPL_APPLRTS
-	OBJECT_FILES += appl-runtime.o applrts-config.o applrts-runtime.o applrts-scheduler.o
+	OBJECT_FILES += appl-malloc.o
+	OBJECT_FILES += appl-runtime.o
+	OBJECT_FILES += applrts-config.o applrts-runtime.o applrts-scheduler.o
 endif
 
 ifeq ($(APPL_IMPL), APPL_IMPL_SERIAL)
 	RISCV_GCC_OPTS +=-DAPPL_IMPL_SERIAL
+	OBJECT_FILES += appl-malloc.o
 endif
 
 ifeq ($(APPL_IMPL), APPL_IMPL_CELLO)

--- a/software/spmd/appl/appl-config.hpp
+++ b/software/spmd/appl/appl-config.hpp
@@ -2,5 +2,7 @@
 // appl-config.h
 //========================================================================
 
-// For debug, we can define APPL_IMPL_APPLRTS here
-// #define APPL_IMPL_APPLRTS
+#ifndef APPL_CONFIG_GLOBAL_H
+#define APPL_CONFIG_GLOBAL_H
+
+#endif

--- a/software/spmd/appl/appl-malloc.cpp
+++ b/software/spmd/appl/appl-malloc.cpp
@@ -1,0 +1,16 @@
+#include "appl-malloc.hpp"
+
+namespace appl {
+
+namespace local {
+
+uint32_t dram_buffer_idx = 0;
+int* dram_buffer;
+
+} // namespace local
+
+void malloc_init(int* dram_buffer) {
+  local::dram_buffer = &(dram_buffer[__bsg_id * BUF_FACTOR * HB_L2_CACHE_LINE_WORDS]);
+}
+
+} // namespace appl

--- a/software/spmd/appl/appl-malloc.hpp
+++ b/software/spmd/appl/appl-malloc.hpp
@@ -1,0 +1,64 @@
+//========================================================================
+// appl-malloc.h
+//========================================================================
+
+#ifndef APPL_MALLOC_GLOBAL_H
+#define APPL_MALLOC_GLOBAL_H
+
+#include <cstddef>
+#include <stdint.h>
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#define HB_L2_CACHE_LINE_WORDS 16
+#define BUF_FACTOR 2049
+
+#define MALLOC_DEBUG 1
+
+// utils
+namespace appl {
+namespace local {
+
+// ref_count stack. This needs to be in the DRAM for AMO
+extern uint32_t dram_buffer_idx;
+
+extern int* dram_buffer;
+
+} // namespace local
+
+void malloc_init(int* dram_buffer);
+
+// linear allocator in DRAM
+inline int* appl_malloc() {
+  int* val = &(local::dram_buffer[local::dram_buffer_idx++]);
+#ifdef MALLOC_DEBUG
+  bsg_print_hexadecimal((intptr_t)val);
+  bsg_print_int(local::dram_buffer_idx);
+#endif
+  if (local::dram_buffer_idx > HB_L2_CACHE_LINE_WORDS * BUF_FACTOR) {
+    bsg_print_int(7600);
+  }
+  return val;
+}
+
+// number of bytes
+inline void* appl_malloc(uint32_t size) {
+  uint32_t size_4 = size >> 2;
+  if (size & 0x3 != 0) {
+    size_4++;
+  }
+  void* val = (void*)(&(local::dram_buffer[local::dram_buffer_idx]));
+  local::dram_buffer_idx += size_4;
+#ifdef MALLOC_DEBUG
+  bsg_print_hexadecimal((intptr_t)val);
+  bsg_print_int(local::dram_buffer_idx);
+#endif
+  if (local::dram_buffer_idx > HB_L2_CACHE_LINE_WORDS * BUF_FACTOR) {
+    bsg_print_int(7600);
+  }
+  return val;
+}
+
+} // namespace appl
+
+#endif

--- a/software/spmd/appl/appl-runtime-applrts.inl
+++ b/software/spmd/appl/appl-runtime-applrts.inl
@@ -2,12 +2,14 @@
 // runtime.inl
 //========================================================================
 
+#include "appl-malloc.hpp"
 #include "applrts.hpp"
 
 namespace appl {
 
 inline void runtime_init( int* dram_buffer, size_t pfor_grain_size ) {
-  applrts::runtime_init( dram_buffer, pfor_grain_size );
+  appl::malloc_init( dram_buffer );
+  applrts::runtime_init( pfor_grain_size );
 }
 
 inline void runtime_end() {

--- a/software/spmd/appl/appl-runtime-serial.inl
+++ b/software/spmd/appl/appl-runtime-serial.inl
@@ -2,9 +2,12 @@
 // runtime.inl
 //========================================================================
 
+#include "appl-malloc.hpp"
+
 namespace appl {
 
 inline void runtime_init( int* dram_buffer, size_t pfor_grain_size ) {
+  appl::malloc_init( dram_buffer );
 }
 
 inline void runtime_end() {

--- a/software/spmd/appl/appl.hpp
+++ b/software/spmd/appl/appl.hpp
@@ -14,5 +14,6 @@
 
 // Utils
 #include "appl-runtime.hpp"
+#include "appl-malloc.hpp"
 
 #endif

--- a/software/spmd/applrts/applrts-config.cpp
+++ b/software/spmd/applrts/applrts-config.cpp
@@ -6,8 +6,6 @@ namespace local {
 
 int seed = 0;
 size_t g_pfor_grain_size = 0;
-uint32_t dram_buffer_idx = 0;
-int* dram_buffer;
 
 } // namespace local
 

--- a/software/spmd/applrts/applrts-runtime.hpp
+++ b/software/spmd/applrts/applrts-runtime.hpp
@@ -21,7 +21,7 @@ extern SimpleDeque<Task*> g_taskq;
 }
 
 // Initialize the runtime with a default scheduler and a thread pool
-void runtime_init( int* dram_buffer, size_t pfor_grain_size = 1 );
+void runtime_init( size_t pfor_grain_size = 1 );
 
 // Get number of threads
 size_t get_nthreads();

--- a/software/spmd/applrts/applrts-runtime.inl
+++ b/software/spmd/applrts/applrts-runtime.inl
@@ -4,15 +4,12 @@
 
 namespace applrts {
 
-inline void runtime_init( int* dram_buffer, size_t pfor_grain_size ) {
+inline void runtime_init( size_t pfor_grain_size ) {
   // set parallel for grain size
   local::g_pfor_grain_size = pfor_grain_size;
 
   // set fast random seed
   local::seed = __bsg_id;
-
-  // set global buffer
-  local::dram_buffer = &(dram_buffer[__bsg_id * BUF_FACTOR * HB_L2_CACHE_LINE_WORDS]);
 
   // init task queue
   local::g_taskq.reset();

--- a/software/spmd/ligra/utils.h
+++ b/software/spmd/ligra/utils.h
@@ -6,7 +6,7 @@
 #if defined(APPL_IMPL_CELLO)
 #define newA( __E, __n ) (__E*)cello::arch::malloc( ( __n ) * sizeof( __E ) )
 #else
-#define newA( __E, __n ) (__E*)applrts::brg_malloc( ( __n ) * sizeof( __E ) )
+#define newA( __E, __n ) (__E*)appl::appl_malloc( ( __n ) * sizeof( __E ) )
 #endif
 
 template <class ET>


### PR DESCRIPTION
In this PR:
 - Lifted `applrts::brg_malloc` to `appl::appl_malloc` so it can be shared between `applrts`, `serial`, and `static` runtime
 - Fix the problem that Ligra apps does not run on serial (see above)