### PR TITLE
[ligra sparse] set block size to 256 in pack and scan

### DIFF
--- a/software/spmd/ligra/sequence.h
+++ b/software/spmd/ligra/sequence.h
@@ -6,7 +6,7 @@
 
 namespace pbbs {
 
-#define _log_block_size 4
+#define _log_block_size _SCAN_LOG_BSIZE
 #define _block_size     ( 1 << _log_block_size )
 
 inline size_t num_blocks( size_t n, size_t block_size )

--- a/software/spmd/ligra/utils.h
+++ b/software/spmd/ligra/utils.h
@@ -9,6 +9,9 @@
 #define newA( __E, __n ) (__E*)appl::appl_malloc( ( __n ) * sizeof( __E ) )
 #endif
 
+#define _SCAN_LOG_BSIZE 8
+#define _SCAN_BSIZE ( 1 << _SCAN_LOG_BSIZE )
+
 template <class E>
 struct addF {
     E operator()( const E& a, const E& b ) const { return a + b; }
@@ -61,9 +64,6 @@ inline ET min(ET a, ET b) {
       }                                                                  \
     }                                                                    \
   }
-
-#define _SCAN_LOG_BSIZE 4
-#define _SCAN_BSIZE ( 1 << _SCAN_LOG_BSIZE )
 
 namespace sequence {
 


### PR DESCRIPTION
In this PR:
 - unify `_log_block_size` and `_SCAN_LOG_BSIZE` <-- this is really a Ligra problem.
 - set `_SCAN_LOG_BSIZE` to `2^8`