### PR TITLE
Appl-Malloc & Ligra Sparse Fix

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -126,6 +126,7 @@ ifeq ($(APPL_IMPL), APPL_IMPL_APPLRTS)
 	OBJECT_FILES += applrts-runtime.o
 	OBJECT_FILES += applrts-scheduler.o
 	OBJECT_FILES += applrts-stats.o
+	OBJECT_FILES += bsg_mcs_mutex.o
 endif
 
 ifeq ($(APPL_IMPL), APPL_IMPL_SERIAL)

--- a/software/spmd/appl/appl-malloc.cpp
+++ b/software/spmd/appl/appl-malloc.cpp
@@ -5,12 +5,22 @@ namespace appl {
 namespace local {
 
 uint32_t dram_buffer_idx = 0;
+uint32_t dram_buffer_end = 0;
 int* dram_buffer;
 
 } // namespace local
 
 void malloc_init(int* dram_buffer) {
-  local::dram_buffer = &(dram_buffer[__bsg_id * BUF_FACTOR * HB_L2_CACHE_LINE_WORDS]);
+  uint32_t total_cachelines = 128 * BUF_FACTOR;
+  uint32_t tile0_cachelines = total_cachelines - 128 * RT_FACTOR;
+
+  local::dram_buffer = &(dram_buffer[__bsg_id * RT_FACTOR * HB_L2_CACHE_LINE_WORDS]);
+  local::dram_buffer_end = RT_FACTOR * HB_L2_CACHE_LINE_WORDS;
+
+  if (__bsg_id == 0) {
+    local::dram_buffer = &(dram_buffer[128 * RT_FACTOR * HB_L2_CACHE_LINE_WORDS]);
+    local::dram_buffer_end = tile0_cachelines * HB_L2_CACHE_LINE_WORDS;
+  }
 }
 
 } // namespace appl

--- a/software/spmd/appl/appl-malloc.hpp
+++ b/software/spmd/appl/appl-malloc.hpp
@@ -11,9 +11,10 @@
 #include "bsg_set_tile_x_y.h"
 
 #define HB_L2_CACHE_LINE_WORDS 16
-#define BUF_FACTOR 2049
+#define BUF_FACTOR 16385
+#define RT_FACTOR 2049
 
-#define MALLOC_DEBUG 1
+#undef MALLOC_DEBUG
 
 // utils
 namespace appl {
@@ -21,6 +22,7 @@ namespace local {
 
 // ref_count stack. This needs to be in the DRAM for AMO
 extern uint32_t dram_buffer_idx;
+extern uint32_t dram_buffer_end;
 
 extern int* dram_buffer;
 
@@ -35,7 +37,7 @@ inline int* appl_malloc() {
   bsg_print_hexadecimal((intptr_t)val);
   bsg_print_int(local::dram_buffer_idx);
 #endif
-  if (local::dram_buffer_idx > HB_L2_CACHE_LINE_WORDS * BUF_FACTOR) {
+  if (local::dram_buffer_idx > local::dram_buffer_end) {
     bsg_print_int(7600);
   }
   return val;
@@ -53,7 +55,7 @@ inline void* appl_malloc(uint32_t size) {
   bsg_print_hexadecimal((intptr_t)val);
   bsg_print_int(local::dram_buffer_idx);
 #endif
-  if (local::dram_buffer_idx > HB_L2_CACHE_LINE_WORDS * BUF_FACTOR) {
+  if (local::dram_buffer_idx > local::dram_buffer_end) {
     bsg_print_int(7600);
   }
   return val;

--- a/software/spmd/appl/appl-runtime-applrts.inl
+++ b/software/spmd/appl/appl-runtime-applrts.inl
@@ -16,7 +16,7 @@ inline void runtime_init( int* dram_buffer, size_t pfor_grain_size ) {
 inline void runtime_end() {
   if (__bsg_id == 0) {
     for (uint32_t i = 1; i < MAX_WORKERS; i++) {
-      int* stop = applrts::remote_ptr(&global::g_stop_flag, i);
+      int* stop = applrts::remote_ptr(&local::g_stop_flag, i);
       *stop = 1;
     }
   }

--- a/software/spmd/appl/appl-runtime-applrts.inl
+++ b/software/spmd/appl/appl-runtime-applrts.inl
@@ -14,13 +14,17 @@ inline void runtime_init( int* dram_buffer, size_t pfor_grain_size ) {
 }
 
 inline void runtime_end() {
-  // this does not order any computation
-  bsg_amoswap(&global::g_stop_flag, 1);
+  if (__bsg_id == 0) {
+    for (uint32_t i = 1; i < MAX_WORKERS; i++) {
+      int* stop = applrts::remote_ptr(&global::g_stop_flag, i);
+      *stop = 1;
+    }
+  }
 }
 
 inline void worker_thread_init() {
   applrts::work_stealing_loop([&]() -> bool {
-      return bsg_amoadd(&global::g_stop_flag, 0);
+      return local::g_stop_flag;
       } );
 }
 

--- a/software/spmd/appl/appl-runtime-applstatic.inl
+++ b/software/spmd/appl/appl-runtime-applstatic.inl
@@ -16,17 +16,28 @@ inline void runtime_init( int* dram_buffer, size_t pfor_grain_size ) {
 inline void runtime_end() {
   if (__bsg_id == 0) {
     appl::sync();
-    // this does not order any computation
-    bsg_amoswap(&global::g_stop_flag, 1);
+    if (__bsg_id == 0) {
+      for (uint32_t i = 1; i < MAX_WORKERS; i++) {
+        int* stop = applrts::remote_ptr(&global::g_stop_flag, i);
+        *stop = 1;
+      }
+    }
     appl::sync();
   }
 }
 
 inline void worker_thread_init() {
-  while (bsg_amoadd(&global::g_stop_flag, 0) == 0) {
+  while (local::g_stop_flag == 0) {
     appl::sync();
     if (applstatic::local::task != nullptr) {
-      applstatic::local::task->execute();
+      size_t size = applstatic::local::task->m_size;
+      char local_task[size];
+      char* src = (char*)(intptr_t)applstatic::local::task;
+      for (uint32_t i = 0; i < size; i++) {
+        local_task[i] = src[i];
+      }
+      applrts::Task* local_task_p = (applrts::Task*)(intptr_t)local_task;
+      local_task_p->execute();
       applstatic::local::task = nullptr;
     }
     appl::sync();

--- a/software/spmd/appl/appl-runtime-applstatic.inl
+++ b/software/spmd/appl/appl-runtime-applstatic.inl
@@ -18,7 +18,7 @@ inline void runtime_end() {
     appl::sync();
     if (__bsg_id == 0) {
       for (uint32_t i = 1; i < MAX_WORKERS; i++) {
-        int* stop = applrts::remote_ptr(&global::g_stop_flag, i);
+        int* stop = applrts::remote_ptr(&local::g_stop_flag, i);
         *stop = 1;
       }
     }

--- a/software/spmd/appl/appl-runtime.cpp
+++ b/software/spmd/appl/appl-runtime.cpp
@@ -6,10 +6,10 @@
 
 namespace appl {
 
-namespace global {
+namespace local {
 
-int g_stop_flag __attribute__ ((section (".dram"))) = 0;
+int g_stop_flag  = 0;
 
-} // namespace global
+} // namespace local
 
 } // namespace appl

--- a/software/spmd/appl/appl-runtime.hpp
+++ b/software/spmd/appl/appl-runtime.hpp
@@ -13,13 +13,13 @@
 
 namespace appl {
 
-namespace global {
+namespace local {
 // global runtime start/stop flag
-extern int g_stop_flag __attribute__ ((section (".dram")));
+extern int g_stop_flag;
 }
 
 // Initialize the runtime with a default scheduler and a thread pool
-void runtime_init( int* dram_buffer, size_t pfor_grain_size = 1 );
+void runtime_init( int* dram_buffer, size_t pfor_grain_size = 0 );
 
 // Terminate runtime by destructing the scheduler and thread pool.
 void runtime_end();

--- a/software/spmd/applrts/applrts-SimpleDeque.hpp
+++ b/software/spmd/applrts/applrts-SimpleDeque.hpp
@@ -26,6 +26,10 @@ public:
   void push_back( const T& item );
   T pop_back();
   T pop_front();
+  // race is allowed here
+  bool unsafe_empty() const {
+    return (m_tail_ptr - m_head_ptr) == 0;
+  }
 
 private:
   T* m_array_rp; // this is a pointer to m_array in remote format

--- a/software/spmd/applrts/applrts-SimpleDeque.hpp
+++ b/software/spmd/applrts/applrts-SimpleDeque.hpp
@@ -10,22 +10,12 @@
 #include "bsg_manycore_atomic.h"
 #include "bsg_set_tile_x_y.h"
 #include "applrts-config.hpp"
+#include "appl-malloc.hpp"
+#include "bsg_mcs_mutex.h"
 
 #define QUEUE_SIZE 160
 
 namespace applrts {
-
-inline void lock(int* lock_ptr) {
-  int lock_val = 1;
-  do {
-    lock_val = bsg_amoswap_aq(lock_ptr, 1);
-  } while (lock_val != 0);
-  return;
-}
-
-inline void unlock(int* lock_ptr) {
-  bsg_amoswap_rl(lock_ptr, 0);
-}
 
 template <typename T>
 class SimpleDeque {
@@ -43,10 +33,18 @@ private:
   T* m_tail_ptr;
   T* m_array_end;
 
-  int* m_mutex_ptr;
+  bsg_mcs_mutex_t* m_mutex_ptr;
+  bsg_mcs_mutex_node_t* m_lcl_rp;
+  bsg_mcs_mutex_node_t m_lcl;
 
   T  m_array[QUEUE_SIZE];
 
+  inline void lock() {
+    bsg_mcs_mutex_acquire(m_mutex_ptr, &m_lcl, m_lcl_rp);
+  }
+  inline void unlock() {
+    bsg_mcs_mutex_release(m_mutex_ptr, &m_lcl, m_lcl_rp);
+  }
 };
 
 } // namespace applrts

--- a/software/spmd/applrts/applrts-SimpleDeque.hpp
+++ b/software/spmd/applrts/applrts-SimpleDeque.hpp
@@ -34,16 +34,16 @@ private:
   T* m_array_end;
 
   bsg_mcs_mutex_t* m_mutex_ptr;
-  bsg_mcs_mutex_node_t* m_lcl_rp;
   bsg_mcs_mutex_node_t m_lcl;
 
   T  m_array[QUEUE_SIZE];
 
+  // lcl_rp has to be the thread local one.
   inline void lock() {
-    bsg_mcs_mutex_acquire(m_mutex_ptr, &m_lcl, m_lcl_rp);
+    bsg_mcs_mutex_acquire(m_mutex_ptr, local::lcl_rp, local::lcl_rp);
   }
   inline void unlock() {
-    bsg_mcs_mutex_release(m_mutex_ptr, &m_lcl, m_lcl_rp);
+    bsg_mcs_mutex_release(m_mutex_ptr, local::lcl_rp, local::lcl_rp);
   }
 };
 

--- a/software/spmd/applrts/applrts-SimpleDeque.inl
+++ b/software/spmd/applrts/applrts-SimpleDeque.inl
@@ -15,11 +15,11 @@ void SimpleDeque<T>::reset() {
   m_tail_ptr  = m_array_rp;
   m_array_end = m_array_rp + QUEUE_SIZE;
 
-  m_mutex_ptr = remote_ptr((int*)0, bsg_x, bsg_y);;
+  m_mutex_ptr = (bsg_mcs_mutex_t*)appl::appl_malloc(sizeof(bsg_mcs_mutex_t));
   bsg_print_hexadecimal((intptr_t)m_mutex_ptr);
-
-  // this does not order anything
-  bsg_amoswap(m_mutex_ptr, 0);
+  m_lcl_rp = remote_ptr(&m_lcl, bsg_x, bsg_y);
+  bsg_print_int(12580);
+  bsg_print_hexadecimal((intptr_t)m_lcl_rp);
 
   bsg_print_int((intptr_t)m_head_ptr);
   bsg_print_int((intptr_t)m_tail_ptr);
@@ -30,7 +30,7 @@ void SimpleDeque<T>::reset() {
 template <typename T>
 void SimpleDeque<T>::push_back( const T& item )
 {
-  lock( m_mutex_ptr );
+  lock();
   asm volatile("": : :"memory");
   if ( m_tail_ptr < m_array_end ) {
     *m_tail_ptr = item;
@@ -42,13 +42,13 @@ void SimpleDeque<T>::push_back( const T& item )
 
   }
   asm volatile("": : :"memory");
-  unlock( m_mutex_ptr );
+  unlock();
 }
 
 template <typename T>
 T SimpleDeque<T>::pop_back()
 {
-  lock( m_mutex_ptr );
+  lock();
   asm volatile("": : :"memory");
   T ret_val = nullptr;
   if ( m_tail_ptr - m_head_ptr > 0 ) {
@@ -60,14 +60,14 @@ T SimpleDeque<T>::pop_back()
     ret_val = *tmp;
   }
   asm volatile("": : :"memory");
-  unlock( m_mutex_ptr );
+  unlock();
   return ret_val;
 }
 
 template <typename T>
 T SimpleDeque<T>::pop_front()
 {
-  lock( m_mutex_ptr );
+  lock();
   asm volatile("": : :"memory");
   T ret_val = nullptr;
   if ( m_tail_ptr - m_head_ptr > 0 ) {
@@ -79,7 +79,7 @@ T SimpleDeque<T>::pop_front()
     ret_val = *tmp;
   }
   asm volatile("": : :"memory");
-  unlock( m_mutex_ptr );
+  unlock();
   return ret_val;
 }
 

--- a/software/spmd/applrts/applrts-SimpleDeque.inl
+++ b/software/spmd/applrts/applrts-SimpleDeque.inl
@@ -16,10 +16,9 @@ void SimpleDeque<T>::reset() {
   m_array_end = m_array_rp + QUEUE_SIZE;
 
   m_mutex_ptr = (bsg_mcs_mutex_t*)appl::appl_malloc(sizeof(bsg_mcs_mutex_t));
+  local::lcl_rp = remote_ptr(&m_lcl, bsg_x, bsg_y);
   bsg_print_hexadecimal((intptr_t)m_mutex_ptr);
-  m_lcl_rp = remote_ptr(&m_lcl, bsg_x, bsg_y);
-  bsg_print_int(12580);
-  bsg_print_hexadecimal((intptr_t)m_lcl_rp);
+  bsg_print_hexadecimal((intptr_t)local::lcl_rp);
 
   bsg_print_int((intptr_t)m_head_ptr);
   bsg_print_int((intptr_t)m_tail_ptr);

--- a/software/spmd/applrts/applrts-Task.hpp
+++ b/software/spmd/applrts/applrts-Task.hpp
@@ -62,6 +62,8 @@ public:
 
   int increment_ready_count();
 
+  size_t m_size;
+
 private:
   // this needs to be a pointer so we can
   // allocate space in DRAM

--- a/software/spmd/applrts/applrts-config.cpp
+++ b/software/spmd/applrts/applrts-config.cpp
@@ -6,6 +6,7 @@ namespace local {
 
 int seed = 0;
 size_t g_pfor_grain_size = 0;
+bsg_mcs_mutex_node_t* lcl_rp;
 
 } // namespace local
 

--- a/software/spmd/applrts/applrts-config.hpp
+++ b/software/spmd/applrts/applrts-config.hpp
@@ -57,6 +57,20 @@ inline T remote_ptr(T ptr, size_t remote_id) {
   return remote_ptr<T>(ptr, remote_x, remote_y);
 }
 
+inline size_t get_grain_size() {
+  size_t grain = local::g_pfor_grain_size;
+  if (grain == 0) {
+    grain = (last - first) / (8 * MAX_WORKERS);
+    if (grain > 32) {
+      grain = 32;
+    }
+    if (grain == 0) {
+      grain = 1;
+    }
+  }
+  return grain;
+}
+
 } // namespace applrts
 
 #endif

--- a/software/spmd/applrts/applrts-config.hpp
+++ b/software/spmd/applrts/applrts-config.hpp
@@ -6,6 +6,7 @@
 #include "bsg_manycore.h"
 #include "bsg_set_tile_x_y.h"
 #include "appl-malloc.hpp"
+#include "bsg_mcs_mutex.h"
 
 #define MAX_WORKERS (bsg_tiles_X * bsg_tiles_Y)
 
@@ -27,6 +28,8 @@ namespace local {
 extern int seed;
 // parallel for grain size
 extern size_t g_pfor_grain_size;
+// mcs lock
+extern bsg_mcs_mutex_node_t* lcl_rp;
 
 } // namespace local
 

--- a/software/spmd/applrts/applrts-config.hpp
+++ b/software/spmd/applrts/applrts-config.hpp
@@ -57,7 +57,7 @@ inline T remote_ptr(T ptr, size_t remote_id) {
   return remote_ptr<T>(ptr, remote_x, remote_y);
 }
 
-inline size_t get_grain_size() {
+inline size_t get_grain_size(size_t first, size_t last) {
   size_t grain = local::g_pfor_grain_size;
   if (grain == 0) {
     grain = (last - first) / (8 * MAX_WORKERS);

--- a/software/spmd/applrts/applrts-config.hpp
+++ b/software/spmd/applrts/applrts-config.hpp
@@ -64,11 +64,11 @@ inline size_t get_grain_size(size_t first, size_t last) {
   size_t grain = local::g_pfor_grain_size;
   if (grain == 0) {
     grain = (last - first) / (8 * MAX_WORKERS);
-    if (grain > 32) {
-      grain = 32;
+    if (grain > 128) {
+      grain = 128;
     }
     if (grain == 0) {
-      grain = 1;
+      grain = 16;
     }
   }
   return grain;

--- a/software/spmd/applrts/applrts-parallel_for.inl
+++ b/software/spmd/applrts/applrts-parallel_for.inl
@@ -5,6 +5,7 @@
 #include "applrts-Range1D.hpp"
 #include "applrts-scheduler.hpp"
 #include "applrts-Task.hpp"
+#include "applrts-config.hpp"
 
 namespace applrts {
 
@@ -133,7 +134,7 @@ void parallel_for( IndexT first, IndexT last, IndexT step,
 {
   if ( first < last ) {
     // use the app-specific grain size
-    size_t grain = local::g_pfor_grain_size;
+    size_t grain = get_grain_size();
 
     IndexT end = ( last - first - IndexT( 1 ) ) / step + IndexT( 1 );
     Range1D<IndexT>               range( IndexT( 0 ), end, grain );

--- a/software/spmd/applrts/applrts-parallel_for.inl
+++ b/software/spmd/applrts/applrts-parallel_for.inl
@@ -134,7 +134,7 @@ void parallel_for( IndexT first, IndexT last, IndexT step,
 {
   if ( first < last ) {
     // use the app-specific grain size
-    size_t grain = get_grain_size();
+    size_t grain = get_grain_size(first, last);
 
     IndexT end = ( last - first - IndexT( 1 ) ) / step + IndexT( 1 );
     Range1D<IndexT>               range( IndexT( 0 ), end, grain );

--- a/software/spmd/applrts/applrts-parallel_reduce.inl
+++ b/software/spmd/applrts/applrts-parallel_reduce.inl
@@ -5,6 +5,7 @@
 #include "applrts-Range1D.hpp"
 #include "applrts-scheduler.hpp"
 #include "applrts-Task.hpp"
+#include "applrts-config.hpp"
 
 namespace applrts {
 
@@ -139,7 +140,8 @@ ValueT parallel_reduce( IndexT first, IndexT last, const ValueT initV,
 {
   if ( first < last ) {
     // use the app-specific grain size
-    size_t grain = local::g_pfor_grain_size;
+    size_t grain = get_grain_size();
+
     IndexT end = ( last - first );
     Range1D<IndexT> range( IndexT( 0 ), end, grain );
     return parallel_reduce(range, initV, func, reduce);

--- a/software/spmd/applrts/applrts-parallel_reduce.inl
+++ b/software/spmd/applrts/applrts-parallel_reduce.inl
@@ -140,7 +140,7 @@ ValueT parallel_reduce( IndexT first, IndexT last, const ValueT initV,
 {
   if ( first < last ) {
     // use the app-specific grain size
-    size_t grain = get_grain_size();
+    size_t grain = get_grain_size(first, last);
 
     IndexT end = ( last - first );
     Range1D<IndexT> range( IndexT( 0 ), end, grain );

--- a/software/spmd/applrts/applrts-runtime.hpp
+++ b/software/spmd/applrts/applrts-runtime.hpp
@@ -21,7 +21,7 @@ extern SimpleDeque<Task*> g_taskq;
 }
 
 // Initialize the runtime with a default scheduler and a thread pool
-void runtime_init( size_t pfor_grain_size = 1 );
+void runtime_init( size_t pfor_grain_size = 0 );
 
 // Get number of threads
 size_t get_nthreads();

--- a/software/spmd/applrts/applrts-scheduler.cpp
+++ b/software/spmd/applrts/applrts-scheduler.cpp
@@ -62,8 +62,13 @@ void __attribute__ ((noinline)) work_stealing_inner_loop() {
     // now found a victim, steal...
 
     SimpleDeque<Task*>* victim_queue = remote_ptr(&local::g_taskq, victim_id);
-    Task* task_p = victim_queue->pop_front();
 
+    // do an unsafe check to see if the victim is out of work
+    if (victim_queue->unsafe_empty()) {
+      return;
+    }
+
+    Task* task_p = victim_queue->pop_front();
     stats::log_stealing_attempt();
 
     if ( task_p ) {

--- a/software/spmd/applrts/applrts-scheduler.cpp
+++ b/software/spmd/applrts/applrts-scheduler.cpp
@@ -60,13 +60,7 @@ void __attribute__ ((noinline)) work_stealing_inner_loop() {
     }
 
     // now found a victim, steal...
-
     SimpleDeque<Task*>* victim_queue = remote_ptr(&local::g_taskq, victim_id);
-
-    // do an unsafe check to see if the victim is out of work
-    if (victim_queue->unsafe_empty()) {
-      return;
-    }
 
     Task* task_p = victim_queue->pop_front();
     stats::log_stealing_attempt();

--- a/software/spmd/applrts/applrts-stats.cpp
+++ b/software/spmd/applrts/applrts-stats.cpp
@@ -3,10 +3,12 @@
 namespace applrts {
 namespace stats {
 
+#ifdef APPL_STATS
 uint32_t s_task_enqueue;
 uint32_t s_task_dequeue;
 uint32_t s_task_stolen;
 uint32_t s_stealing_attempt;
+#endif
 
 __attribute__ ((noinline)) void dump_stats() {
 #ifdef APPL_STATS

--- a/software/spmd/applrts/applrts-stats.hpp
+++ b/software/spmd/applrts/applrts-stats.hpp
@@ -6,7 +6,7 @@
 #define APPLRTS_STATS_H
 
 // stats enable
-#define APPL_STATS
+#undef APPL_STATS
 
 #ifdef APPL_STATS
 

--- a/software/spmd/applstatic/applstatic-config.hpp
+++ b/software/spmd/applstatic/applstatic-config.hpp
@@ -53,11 +53,11 @@ inline size_t get_grain_size(size_t first, size_t last) {
   size_t grain = local::g_pfor_grain_size;
   if (grain == 0) {
     grain = (last - first) / (8 * MAX_WORKERS);
-    if (grain > 32) {
-      grain = 32;
+    if (grain > 128) {
+      grain = 128;
     }
     if (grain == 0) {
-      grain = 1;
+      grain = 16;
     }
   }
   return grain;

--- a/software/spmd/applstatic/applstatic-config.hpp
+++ b/software/spmd/applstatic/applstatic-config.hpp
@@ -49,7 +49,7 @@ inline T remote_ptr(T ptr, size_t remote_id) {
 }
 */
 
-inline size_t get_grain_size() {
+inline size_t get_grain_size(size_t first, size_t last) {
   size_t grain = local::g_pfor_grain_size;
   if (grain == 0) {
     grain = (last - first) / (8 * MAX_WORKERS);

--- a/software/spmd/applstatic/applstatic-config.hpp
+++ b/software/spmd/applstatic/applstatic-config.hpp
@@ -49,6 +49,20 @@ inline T remote_ptr(T ptr, size_t remote_id) {
 }
 */
 
+inline size_t get_grain_size() {
+  size_t grain = local::g_pfor_grain_size;
+  if (grain == 0) {
+    grain = (last - first) / (8 * MAX_WORKERS);
+    if (grain > 32) {
+      grain = 32;
+    }
+    if (grain == 0) {
+      grain = 1;
+    }
+  }
+  return grain;
+}
+
 } // namespace applstatic
 
 #endif

--- a/software/spmd/applstatic/applstatic-parallel_for.inl
+++ b/software/spmd/applstatic/applstatic-parallel_for.inl
@@ -6,6 +6,7 @@
 #include "applstatic-runtime.hpp"
 #include "applrts-Task.hpp"
 #include "appl-hw-barrier.hpp"
+#include "applstatic-config.hpp"
 
 namespace applstatic {
 
@@ -23,6 +24,7 @@ public:
       : m_first( first ), m_last( last ), m_step( step ),
         m_grain( grain ), m_body( body )
   {
+    m_size = sizeof(ParallelForTask<IndexT, BodyT>);
   }
 
   Task* execute()
@@ -81,17 +83,14 @@ void parallel_for( IndexT first, IndexT last, IndexT step,
       }
 
       // task assignment
-      for (uint32_t i = 0; i < MAX_WORKERS; i++) {
+      for (uint32_t i = 1; i < MAX_WORKERS; i++) {
         applrts::Task** core_task = applrts::remote_ptr(&local::task, i);
         *core_task = task;
       }
 
       local::is_top_level = false;
       appl::sync();
-      if (local::task != nullptr) {
-        local::task->execute();
-        local::task = nullptr;
-      }
+      local_task.execute();
       appl::sync();
       local::is_top_level = true;
     } else {
@@ -108,7 +107,8 @@ void parallel_for( IndexT first, IndexT last, IndexT step,
                    const BodyT& body )
 {
   // use the app-specific grain size
-  size_t grain = local::g_pfor_grain_size;
+  size_t grain = get_grain_size();
+
   parallel_for( first, last, step, body, grain );
 }
 

--- a/software/spmd/applstatic/applstatic-parallel_for.inl
+++ b/software/spmd/applstatic/applstatic-parallel_for.inl
@@ -107,7 +107,7 @@ void parallel_for( IndexT first, IndexT last, IndexT step,
                    const BodyT& body )
 {
   // use the app-specific grain size
-  size_t grain = get_grain_size();
+  size_t grain = get_grain_size(first, last);
 
   parallel_for( first, last, step, body, grain );
 }

--- a/software/spmd/applstatic/applstatic-parallel_reduce.inl
+++ b/software/spmd/applstatic/applstatic-parallel_reduce.inl
@@ -58,7 +58,7 @@ ValueT parallel_reduce( IndexT first, IndexT last, const ValueT initV,
 {
   if ( first < last ) {
     // use the app-specific grain size
-    size_t grain = get_grain_size();
+    size_t grain = get_grain_size(first, last);
 
     if (local::is_top_level) {
       // partial value buffer

--- a/software/spmd/applstatic/applstatic-parallel_reduce.inl
+++ b/software/spmd/applstatic/applstatic-parallel_reduce.inl
@@ -3,6 +3,7 @@
 //========================================================================
 
 #include "applrts-Task.hpp"
+#include "applstatic-config.hpp"
 
 namespace applstatic {
 
@@ -20,6 +21,7 @@ public:
       : m_first( first ), m_last( last ), m_initV( initV ),
         m_grain( grain ), m_func( func ), m_pvalues( pvalues )
   {
+    m_size = sizeof(ParallelReduceTask<IndexT, ValueT, FuncT>);
   }
 
   Task* execute()
@@ -56,7 +58,7 @@ ValueT parallel_reduce( IndexT first, IndexT last, const ValueT initV,
 {
   if ( first < last ) {
     // use the app-specific grain size
-    size_t grain = local::g_pfor_grain_size;
+    size_t grain = get_grain_size();
 
     if (local::is_top_level) {
       // partial value buffer
@@ -84,7 +86,7 @@ ValueT parallel_reduce( IndexT first, IndexT last, const ValueT initV,
 
       local::is_top_level = false;
       appl::sync();
-      local::task->execute();
+      local_task.execute();
       appl::sync();
       local::is_top_level = true;
 

--- a/software/spmd/applstatic/applstatic-runtime.hpp
+++ b/software/spmd/applstatic/applstatic-runtime.hpp
@@ -22,7 +22,7 @@ extern applrts::Task* task;
 }
 
 // Initialize the runtime with a default scheduler and a thread pool
-void runtime_init( size_t pfor_grain_size = 1 );
+void runtime_init( size_t pfor_grain_size = 0 );
 
 // Get number of threads
 size_t get_nthreads();

--- a/software/spmd/bsg_cuda_lite_runtime/appl-bfs/kernel_appl_bfs.cpp
+++ b/software/spmd/bsg_cuda_lite_runtime/appl-bfs/kernel_appl_bfs.cpp
@@ -31,20 +31,19 @@ struct BFS_F {
 };
 
 template <class vertex>
-void Compute( graph<vertex>& GA, size_t start, int* results ) {
+void Compute( graph<vertex>& GA, size_t start, uintE* results ) {
   size_t n     = GA.n;
   uintE* Parents = newA( uintE, n );
-  uintE* bfsLvls = newA( uintE, n );
   appl::parallel_for( size_t( 0 ), n, [&]( size_t i ) {
       Parents[i] = UINT_E_MAX;
-      bfsLvls[i] = UINT_E_MAX;
+      results[i] = UINT_E_MAX;
       } );
   Parents[start] = start;
   vertexSubset Frontier( n, start ); // creates initial frontier
 
   uintE lvl = 0;
   while ( !Frontier.isEmpty() ) {    // loop until frontier is empty
-    vertexSubset output = edgeMap( GA, Frontier, BFS_F( Parents, bfsLvls, lvl ) );
+    vertexSubset output = edgeMap( GA, Frontier, BFS_F( Parents, results, lvl ) );
     Frontier.del();
     Frontier = output; // set new frontier
     lvl++;
@@ -53,11 +52,6 @@ void Compute( graph<vertex>& GA, size_t start, int* results ) {
     bsg_print_int(Frontier.numNonzeros());
   }
 
-  // print
-  for (size_t i = 0; i < GA.n; i++) {
-    results[i] = bfsLvls[i];
-    // bsg_print_int(bfsLvls[i]);
-  }
   Frontier.del();
 }
 
@@ -70,7 +64,7 @@ int kernel_appl_bfs(int* results, symmetricVertex* V, int n, int m, int start, i
 
   if (__bsg_id == 0) {
     graph<symmetricVertex> G = graph<symmetricVertex>(V, n, m, nullptr);
-    Compute(G, start, results);
+    Compute(G, start, (uintE*)(intptr_t)results);
   } else {
     appl::worker_thread_init();
   }

--- a/software/spmd/bsg_cuda_lite_runtime/appl-bfs/kernel_appl_bfs.cpp
+++ b/software/spmd/bsg_cuda_lite_runtime/appl-bfs/kernel_appl_bfs.cpp
@@ -31,9 +31,8 @@ struct BFS_F {
 };
 
 template <class vertex>
-void Compute( graph<vertex>& GA, int* results ) {
+void Compute( graph<vertex>& GA, size_t start, int* results ) {
   size_t n     = GA.n;
-  size_t start = 1;
   uintE* Parents = newA( uintE, n );
   uintE* bfsLvls = newA( uintE, n );
   appl::parallel_for( size_t( 0 ), n, [&]( size_t i ) {
@@ -63,7 +62,7 @@ void Compute( graph<vertex>& GA, int* results ) {
 }
 
 extern "C" __attribute__ ((noinline))
-int kernel_appl_bfs(int* results, symmetricVertex* V, int n, int m, int* dram_buffer) {
+int kernel_appl_bfs(int* results, symmetricVertex* V, int n, int m, int start, int* dram_buffer) {
 
   appl::runtime_init(dram_buffer, 16);
   appl::sync();
@@ -71,7 +70,7 @@ int kernel_appl_bfs(int* results, symmetricVertex* V, int n, int m, int* dram_bu
 
   if (__bsg_id == 0) {
     graph<symmetricVertex> G = graph<symmetricVertex>(V, n, m, nullptr);
-    Compute(G, results);
+    Compute(G, start, results);
   } else {
     appl::worker_thread_init();
   }

--- a/software/spmd/bsg_cuda_lite_runtime/appl-bfs/kernel_appl_bfs.cpp
+++ b/software/spmd/bsg_cuda_lite_runtime/appl-bfs/kernel_appl_bfs.cpp
@@ -64,7 +64,7 @@ void Compute( graph<vertex>& GA, size_t start, int* results ) {
 extern "C" __attribute__ ((noinline))
 int kernel_appl_bfs(int* results, symmetricVertex* V, int n, int m, int start, int* dram_buffer) {
 
-  appl::runtime_init(dram_buffer, 16);
+  appl::runtime_init(dram_buffer);
   appl::sync();
   bsg_cuda_print_stat_kernel_start();
 

--- a/software/spmd/bsg_cuda_lite_runtime/appl-fib/kernel_appl_fib.cpp
+++ b/software/spmd/bsg_cuda_lite_runtime/appl-fib/kernel_appl_fib.cpp
@@ -2,10 +2,6 @@
 #include "bsg_manycore.h"
 #include "appl.hpp"
 
-#include "bsg_tile_group_barrier.hpp"
-
-bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
-
 int32_t fib_base(int32_t n) {
   if (n < 2)
     return n;
@@ -44,7 +40,7 @@ int kernel_appl_fib(int* results, int n, int grain_size, int* dram_buffer) {
   appl::runtime_init(dram_buffer, 2);
 
   // sync
-  barrier.sync();
+  appl::sync();
   bsg_cuda_print_stat_kernel_start();
 
   if (__bsg_id == 0) {
@@ -59,6 +55,6 @@ int kernel_appl_fib(int* results, int n, int grain_size, int* dram_buffer) {
   bsg_cuda_print_stat_kernel_end();
   bsg_print_int(result);
 
-  barrier.sync();
+  appl::sync();
   return 0;
 }

--- a/software/spmd/ligra/ligra.h
+++ b/software/spmd/ligra/ligra.h
@@ -140,6 +140,13 @@ vertexSubset edgeMap( graph<vertex> GA, VS& vs, F f, intT threshold = -1,
     return vertexSubset( numVertices );
   }
 
+  // shortcut -- if m is already larger than threshold
+  // then we dont need to convert back and forth
+  if ( m > threshold ) {
+    vs.toDense();
+    return edgeMapDense<vertex, VS, F>( GA, vs, f, fl );
+  }
+
   vs.toSparse();
   uintT*  degrees          = newA( uintT, m );
   vertex* frontierVertices = newA( vertex, m );

--- a/software/spmd/ligra/sequence.h
+++ b/software/spmd/ligra/sequence.h
@@ -76,7 +76,7 @@ size_t filterf( T* In, T* Out, size_t n, PRED p ) {
       T* ptr = Out + Sums[i];
       for ( size_t idx = s; idx < e; idx++ ) {
         if( p( In[idx] ) ) {
-          *ptr = idx;
+          *ptr = In[idx];
           ptr++;
         }
       }

--- a/software/spmd/ligra/utils.h
+++ b/software/spmd/ligra/utils.h
@@ -82,7 +82,7 @@ struct getA {
     intT _ee = _e;                                                       \
     intT _n  = _ee - _ss;                                                \
     intT _l  = nblocks( _n, _bsize );                                    \
-    appl::parallel_for( (intT)0, _l, [&]( intT i ) {                     \
+    appl::parallel_for_1( (intT)0, _l, [&]( intT i ) {                     \
       intT _s = _ss + _i * ( _bsize );                                   \
       intT _e = min( _s + ( _bsize ), _ee );                             \
       _body                                                              \


### PR DESCRIPTION
In this PR:
 - allocate more space to tile0 for user level memory allocation in appl-malloc
 - switched to use MCS locks
 - performs an unsafe peek before stealing from a victim
 - fix a bug in ligra sparse API which leads to incorrect next vertexSubset 
 - use default grain size if init'ed to `0`